### PR TITLE
Update bvh_parser.py

### DIFF
--- a/retargeting/datasets/bvh_parser.py
+++ b/retargeting/datasets/bvh_parser.py
@@ -136,7 +136,7 @@ class BVH_file:
 
         for name in corps_names[self.skeleton_type]:
             for j in range(self.anim.shape[1]):
-                if name in self._names[j]:
+                if name == self._names[j]:
                     self.corps.append(j)
                     break
 


### PR DESCRIPTION
For me that little detail caused problems.
No idea why it doesn't cause problems on the example data.
Maybe depends on the order the bones appear in the bvh.
For example for me it created 3 times the same bone in the corps array. (The bone "Spine1_split", because "Spine1" was part of the name).

And that caused an error while tryint access an invalid index at:
https://github.com/TheCrazyT/deep-motion-editing/blob/4b5b47916131ebd45dc37c8a8d14440d25fda0cd/retargeting/datasets/bvh_parser.py#L190