### PR TITLE
Stylization version of kinematics.py missing previous bugfix.

### DIFF
--- a/style_transfer/kinematics.py
+++ b/style_transfer/kinematics.py
@@ -81,7 +81,7 @@ class ForwardKinematics:
 
             result[..., i, :] = torch.matmul(transform[..., pi, :, :], self.offset[i])
             if world: result[..., i, :] += result[..., pi, :]
-            transform[..., i, :, :] = torch.matmul(transform[..., pi, :, :], transform[..., i, :, :])
+            transform[..., i, :, :] = torch.matmul(transform[..., pi, :, :].clone(), transform[..., i, :, :].clone())
         return result
 
     @staticmethod


### PR DESCRIPTION
Fixing bug similar to bugfix: DeepMotionEditing#166.
kinematics.py in the stylization folder also needed the .clone() fix.

RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.FloatTensor ..., which is output 0 of ViewBackward, is at version 37; expected version 35 instead.